### PR TITLE
bugfix(modflow.py): need to specify delc for pixel width and rot angle

### DIFF
--- a/mfobs/modflow.py
+++ b/mfobs/modflow.py
@@ -658,8 +658,8 @@ def get_modelgrid_transform(grid_json_file, shift_to_cell_centers=False):
         xul += 0.5 * cfg['delr']
         yul -= 0.5 * cfg['delc']
 
-    transform = Affine(cfg['delc'], 0., xul,
-                       0., -cfg['delr'], yul) * \
+    transform = Affine(cfg['delr'], 0., xul,
+                       0., -cfg['delc'], yul) * \
                 Affine.rotation(-cfg['angrot'])
     return transform
 

--- a/mfobs/modflow.py
+++ b/mfobs/modflow.py
@@ -658,9 +658,9 @@ def get_modelgrid_transform(grid_json_file, shift_to_cell_centers=False):
         xul += 0.5 * cfg['delr']
         yul -= 0.5 * cfg['delc']
 
-    transform = Affine(cfg['delr'], 0., xul,
+    transform = Affine(cfg['delc'], 0., xul,
                        0., -cfg['delr'], yul) * \
-                Affine.rotation(cfg['angrot'])
+                Affine.rotation(-cfg['angrot'])
     return transform
 
 


### PR DESCRIPTION
Two small things for getting affine from `modelgrid.json`:

First, if the a parameter is the width of a pixel, this should be `delc` rather than `delr`.

Second, I got goofy results on a rotated grid relative to a transform made using `modflow-export` using`MFexportGrid`. The difference was the `b` and `e` had opposite sign. Flipping the sign in the `Affine().rotation(angle)` call fixed this. However, I realize this is inconsistent with the docstring here: https://github.com/rasterio/affine/blob/master/affine/tests/test_rotation.py. Maybe the modegrid.json convention is reversed? In any case, making this switch resulted in proper results for this rotated model (18 degrees anticlockwise) and not reversing the angle resulted in negative values for `r` in the `get_ij` funciton.