### PR TITLE
fix(mfobs/obs.py): avoid potential ValueError with pandas.to_datetime…

### DIFF
--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -26,3 +26,7 @@ Published applications of Modflow-obs
 Leaf, A.T., Duncan, L.L., Haugh, C.J., Hunt, R.J., and Rigby, J.R., 2023, Simulating groundwater flow in the Mississippi Alluvial Plain with a focus on the Mississippi Delta: U.S. Geological Survey Scientific Investigations Report 2023–5100, 143 p. `<https://doi.org/10.3133/sir20235100>`_
 
 Leaf, A.T., Duncan, L.L, and Haugh, C.J., 2023, MODFLOW 6 models for simulating groundwater flow in the Mississippi Embayment with a focus on the Mississippi Delta: U.S. Geological Survey data release, `<https://doi.org/10.5066/P971LPOB>`_
+
+Leaf, A.T., Haserodt, M.J., Meyer, B.E., Westenbroek, S.M., and Koch, J.C., 2024, Simulating present and future
+groundwater/surface-water interactions and stream temperatures in Beaver Creek, Kenai Peninsula, Alaska:
+U.S. Geological Survey Scientific Investigations Report 2024–5126, 111 p., `<https://doi.org/10.3133/sir20245126>`_.

--- a/mfobs/modflow.py
+++ b/mfobs/modflow.py
@@ -212,7 +212,7 @@ def get_mf6_single_variable_obs(perioddata,
                                 names_include_variable=False,
                                 abs=True,
                                 gwf_obs_block=None):
-    """Read raw MODFLOW-6 observation output from csv table with
+    r"""Read raw MODFLOW-6 observation output from csv table with
     times along the row axis and observations along the column axis. Reshape
     (stack) results to be n times x n sites rows, with a single observation value
     in each row. If there is more than one time in a stress period, retain only
@@ -494,7 +494,7 @@ def get_mf_gage_package_obs(perioddata,
                             gwf_obs_input_file=None,
                             variable='flow',
                             abs=True):
-    """Read raw MODFLOW gage package text file output with
+    r"""Read raw MODFLOW gage package text file output with
     times along the row axis and observations along the column axis. Reshape
     (stack) results to be n times x n sites rows, with a single observation value
     in each row. 

--- a/mfobs/obs.py
+++ b/mfobs/obs.py
@@ -33,7 +33,7 @@ def get_base_obs(perioddata,
             steady_state_period_end=None, forecast_sites=None,
             forecast_start_date=None, forecast_end_date=None,
             forecasts_only=False, forecast_sites_only=False,
-            outfile=None,
+            outfile=None, verbose=True,
             write_ins=False):
     """Get a set of base observations from a tables of model output, observed 
     values, and model time discretizaton.
@@ -179,6 +179,14 @@ def get_base_obs(perioddata,
         with `forecast_sites` (has no effect if ``forecast_sites='all'``). If
         ``forecasts_only=False``, the output will include forecast and non-forecast
         observations (for a continuous time-series).
+    verbose : bool
+        Controls the verbosity of screen outputs. If True, warnings will be printed
+        when there are no observations within a stress period and forecast_sites is None, 
+        (meaning no observation results will be processed for that stress period), or when
+        supplied observations fall outside of the model timeframe. Within a workflow,
+        verbose can be set equal to write_ins for initial debugging, and the subsequently
+        set False during history matching runs.
+        by default, True
     outfile : str, optional
         [description], by default 'processed_flux_obs.dat'
     write_ins : bool, optional
@@ -392,7 +400,7 @@ def get_base_obs(perioddata,
             observed, start, end, 
             aggregrate_observed_values_method=aggregrate_observed_values_method,
             obsnme_suffix=suffix)
-        if forecast_sites is None and len(observed_in_period_rs) == 0:
+        if verbose and (forecast_sites is None) and (len(observed_in_period_rs) == 0):
             if per_column == 'per':
                 warnings.warn(('Stress period {}: No observations between start and '
                                 'end dates of {} and {}!'.format(r['per'], start, end)))
@@ -405,7 +413,7 @@ def get_base_obs(perioddata,
             aggregrate_observed_values_method=aggregrate_observed_values_method,
             obsnme_suffix=suffix)
         
-        if sim_in_period_rs is None or len(sim_in_period_rs) == 0:
+        if verbose and (sim_in_period_rs is None) or (len(sim_in_period_rs) == 0):
             if per_column == 'per':
                 warnings.warn(('Stress period {}: No simulated equivalents between start and '
                                 'end dates of {} and {}!'.format(r['per'], start, end)))
@@ -418,7 +426,7 @@ def get_base_obs(perioddata,
             observed_in_period_rs['datetime'] = sim_in_period_rs['datetime'].values[0]
         any_simulated_obs = sim_in_period_rs.obsnme.isin(observed_in_period_rs.obsnme).any()
         
-        if not any_simulated_obs and (per_column == 'per'):
+        if verbose and not any_simulated_obs and (per_column == 'per'):
             warnings.warn(('Stress period {}: No observation/simulated equivalent pairs for start and '
                             'end dates of {} and {}!'.format(r['per'], start, end)))
             continue

--- a/mfobs/obs.py
+++ b/mfobs/obs.py
@@ -578,7 +578,7 @@ def get_spatial_differences(base_data, perioddata,
                             use_gradients=False,
                             sep='-d-',
                             write_ins=False, outfile=None):
-    """Takes the base_data dataframe output by :func:`mfobs.obs.get_obs` and creates
+    r"""Takes the base_data dataframe output by :func:`mfobs.obs.get_obs` and creates
     spatial difference observations. Optionally writes an output csvfile
     and a PEST instruction file.
 
@@ -1145,7 +1145,7 @@ def get_annual_means(base_data,
                      obgnme_suffix='annual-mean',
                      outfile=None,
                      write_ins=False):
-    """Create observations of annual mean values for a set of 
+    r"""Create observations of annual mean values for a set of 
     base observations. Means are computed for all columns with 
     floating point data.
 
@@ -1263,7 +1263,7 @@ def get_monthly_means(base_data,
                       obgnme_suffix='monthly-mean',
                       outfile=None,
                       write_ins=False):
-    """Create observations of monthly mean values for a set of 
+    r"""Create observations of monthly mean values for a set of 
     base observations. Means are computed for all columns with 
     floating point data.
 
@@ -1383,7 +1383,7 @@ def get_mean_monthly(base_data,
                      obgnme_suffix='mean-monthly',
                      outfile=None,
                      write_ins=False):
-    """Create observations of mean monthly, or means for months of the year
+    r"""Create observations of mean monthly, or means for months of the year
     (for example, the mean for Jan. across all years). Means are computed for 
     all columns with floating point data.
 
@@ -1505,7 +1505,7 @@ def get_log10_observations(base_data,
                            fill_zeros_with=0,
                            outfile=None,
                            write_ins=False):
-    """Create observations of log values. Log values are computed for 
+    r"""Create observations of log values. Log values are computed for 
     all columns with floating point data.
 
     Parameters
@@ -1613,7 +1613,7 @@ def get_baseflow_observations(base_data,
                               missing_obs_fill_value=0.,
                               outfile=None,
                               write_ins=False, **kwargs):
-    """Create observations of base flow using the 
+    r"""Create observations of base flow using the 
     BFI/Institute of Hydrology hydrograph separation method (:func:`mfobs.sep.ih_method`).
     
     

--- a/mfobs/obs.py
+++ b/mfobs/obs.py
@@ -1003,7 +1003,7 @@ def get_temporal_differences(base_data, perioddata,
     if isinstance(exclude_suffix, str):
         exclude_suffix = [exclude_suffix]
     suffix = [obsnme.split('_')[1] for obsnme in base_data.obsnme]
-    keep = ~np.in1d(suffix, exclude_suffix)
+    keep = ~np.isin(suffix, exclude_suffix)
     base_data = base_data.loc[keep].copy()
 
     # group observations by site (prefix)
@@ -1213,7 +1213,7 @@ def get_annual_means(base_data,
     if isinstance(exclude_suffix, str):
         exclude_suffix = [exclude_suffix]
     suffix = [obsnme.split('_')[1] for obsnme in base_data.obsnme]
-    keep = ~np.in1d(suffix, exclude_suffix)
+    keep = ~np.isin(suffix, exclude_suffix)
     base_data = base_data.loc[keep].copy()
     
     # only include times where there are both an observation and sim. equivalent
@@ -1331,7 +1331,7 @@ def get_monthly_means(base_data,
     if isinstance(exclude_suffix, str):
         exclude_suffix = [exclude_suffix]
     suffix = [obsnme.split('_')[1] for obsnme in base_data.obsnme]
-    keep = ~np.in1d(suffix, exclude_suffix)
+    keep = ~np.isin(suffix, exclude_suffix)
     base_data = base_data.loc[keep].copy()
     
     # only include times where there are both an observation and sim. equivalent
@@ -1451,7 +1451,7 @@ def get_mean_monthly(base_data,
     if isinstance(exclude_suffix, str):
         exclude_suffix = [exclude_suffix]
     suffix = [obsnme.split('_')[1] for obsnme in base_data.obsnme]
-    keep = ~np.in1d(suffix, exclude_suffix)
+    keep = ~np.isin(suffix, exclude_suffix)
     base_data = base_data.loc[keep].copy()
     
     # only include times where there are both an observation and sim. equivalent
@@ -1569,7 +1569,7 @@ def get_log10_observations(base_data,
     if isinstance(exclude_suffix, str):
         exclude_suffix = [exclude_suffix]
     suffix = [obsnme.split('_')[1] for obsnme in base_data.obsnme]
-    keep = ~np.in1d(suffix, exclude_suffix)
+    keep = ~np.isin(suffix, exclude_suffix)
     base_data = base_data.loc[keep].copy()
     
     log_base_data = base_data.copy()
@@ -1687,7 +1687,7 @@ def get_baseflow_observations(base_data,
     if isinstance(exclude_suffix, str):
         exclude_suffix = [exclude_suffix]
     suffix = [obsnme.split('_')[1] for obsnme in base_data.obsnme]
-    keep = ~np.in1d(suffix, exclude_suffix)
+    keep = ~np.isin(suffix, exclude_suffix)
     base_data = base_data.loc[keep].copy()
     
     bf_base_data = base_data.copy()

--- a/mfobs/obs.py
+++ b/mfobs/obs.py
@@ -292,7 +292,10 @@ def get_base_obs(perioddata,
     # cast datetimes to pandas datetimes
     # (observed data may not have a datetime col. if model is steady-state)
     if observed_values_datetime_col is not None and 'datetime' in observed.columns:
-        observed['datetime'] = pd.to_datetime(observed['datetime'])
+        try:
+            observed['datetime'] = pd.to_datetime(observed['datetime'])
+        except ValueError:
+            observed['datetime'] = pd.to_datetime(observed['datetime'], format='mixed')
         # not necessarily True
         observed['steady'] = False  # flag for steady-state observations
     elif label_period_as_steady_state is not None:

--- a/mfobs/tests/test_utils.py
+++ b/mfobs/tests/test_utils.py
@@ -32,11 +32,20 @@ def test_set_period_start_end_dates(test_data_path):
     pd.testing.assert_series_equal(pd.to_datetime(perioddata['start_datetime']), 
                                    pd.to_datetime(perioddata['end_datetime']), 
                                    check_names=False)
+    # test with no initial steady-state period
+    # for example, if we truncate some number of initial periods
+    # so as not to generate observations for those
+    perioddata2 = perioddata.iloc[1:].copy()
+    perioddata2['time'] += 100
+    set_period_start_end_dates(perioddata2)
+    pd.testing.assert_series_equal(pd.to_datetime(perioddata2['start_datetime']), 
+                                   pd.to_datetime(perioddata2['end_datetime']), 
+                                   check_names=False)
     
     # test without time column
     perioddata = pd.DataFrame({
         'start_datetime': pd.date_range('2020-01-01', '2020-12-31', freq='MS'),
-        'end_datetime': pd.date_range('2020-01-01', '2020-12-31', freq='M')
+        'end_datetime': pd.date_range('2020-01-01', '2020-12-31', freq='ME')
     })
     set_period_start_end_dates(perioddata)
     assert 'time' in perioddata.columns


### PR DESCRIPTION
… when datetime (strings) in observed_values_file have mixed formats, for example with some having hh:mm:ss and some not, by adding format='mixed' arg if the first call to pandas.to_datetime fails.