### PR TITLE
fix(obs.get_base_obs): explicitly set obsval and sim_obsval columns a…

### DIFF
--- a/mfobs/obs.py
+++ b/mfobs/obs.py
@@ -514,6 +514,12 @@ def get_base_obs(perioddata,
         obsdata['obsval'] = obsdata[output_obs_values_column]
         columns.insert(-1, 'obsval')
 
+    set_dtypes = {
+        'obsval': float,
+        'sim_obsval': float
+    }
+    for col, dtype in set_dtypes.items():
+        obsdata[col] = obsdata[col].astype(dtype)
 
     # reorder the columns
     columns = [c for c in columns if c in obsdata.columns]

--- a/mfobs/tests/test_obs.py
+++ b/mfobs/tests/test_obs.py
@@ -137,7 +137,14 @@ def test_get_flux_obs(flux_obs):
     assert len(set(results.obsnme)) == len(results)
     assert not results['obsval'].isna().any()
     assert not results.obsnme.str.isupper().any()
-
+    
+    expected_dtypes = {
+        'obsval': float,
+        'sim_obsval': float
+    }
+    for col, dtype in expected_dtypes.items():
+        assert results[col].dtype == dtype
+        
     # check sorting
     assert np.all(results.reset_index(drop=True).groupby('obsprefix').per.diff().dropna() > 0)
 
@@ -152,6 +159,13 @@ def test_get_flux_obs_per_based_suffixes(flux_obs_per_based_suffixes):
     assert not results['obsval'].isna().any()
     assert not results.obsnme.str.isupper().any()
 
+    expected_dtypes = {
+        'obsval': float,
+        'sim_obsval': float
+    }
+    for col, dtype in expected_dtypes.items():
+        assert results[col].dtype == dtype
+        
     # check sorting
     assert np.all(results.reset_index(drop=True).groupby('obsprefix').per.diff().dropna() > 0)
     


### PR DESCRIPTION
…s float, to avoid potential downstream issues with object column dtypes, which can result in columns getting dropped in derivative observation processing.